### PR TITLE
4  configure users at runtime

### DIFF
--- a/BabelBot.sln
+++ b/BabelBot.sln
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "unit", "unit", "{74FB902B-8
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BabelBot.Receiver.Commands.Tests.Unit", "tests\unit\BabelBot.Receiver.Commands.Tests.Unit\BabelBot.Receiver.Commands.Tests.Unit.csproj", "{E281779C-2656-4EED-A724-0B04F8F6D0F1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BabelBot.Storage", "src\BabelBot.Storage\BabelBot.Storage.csproj", "{85DF5F0D-9B07-497D-9626-FE871E7D0696}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/BabelBot.sln
+++ b/BabelBot.sln
@@ -1,5 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+#
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BabelBot.Worker", "src\BabelBot.Worker\BabelBot.Worker.csproj", "{62EEFF90-B342-4799-BC97-B4F5F495DEB0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BabelBot.Shared", "src\BabelBot.Shared\BabelBot.Shared.csproj", "{6C07F17F-C260-4C27-B1C8-A4CF24730303}"
@@ -7,6 +8,14 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BabelBot.Translator.DeepL", "src\BabelBot.Translator.DeepL\BabelBot.Translator.DeepL.csproj", "{FB871688-7485-424C-8626-BFDB04027AC1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BabelBot.Receiver.Telegram", "src\BabelBot.Receiver.Telegram\BabelBot.Receiver.Telegram.csproj", "{72561E09-1DE7-4692-9F1D-73190DF2E657}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BabelBot.Receiver.Commands", "src\BabelBot.Receiver.Commands\BabelBot.Receiver.Commands.csproj", "{C61C0BA4-A8C9-4F6F-9F78-F9B62E07CB4A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0759AA78-9851-423A-9ABF-7022615B85E2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "unit", "unit", "{74FB902B-8258-403A-AF21-B0BE144AF8EC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BabelBot.Receiver.Commands.Tests.Unit", "tests\unit\BabelBot.Receiver.Commands.Tests.Unit\BabelBot.Receiver.Commands.Tests.Unit.csproj", "{E281779C-2656-4EED-A724-0B04F8F6D0F1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,5 +39,21 @@ Global
 		{72561E09-1DE7-4692-9F1D-73190DF2E657}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{72561E09-1DE7-4692-9F1D-73190DF2E657}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{72561E09-1DE7-4692-9F1D-73190DF2E657}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C61C0BA4-A8C9-4F6F-9F78-F9B62E07CB4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C61C0BA4-A8C9-4F6F-9F78-F9B62E07CB4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C61C0BA4-A8C9-4F6F-9F78-F9B62E07CB4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C61C0BA4-A8C9-4F6F-9F78-F9B62E07CB4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E281779C-2656-4EED-A724-0B04F8F6D0F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E281779C-2656-4EED-A724-0B04F8F6D0F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E281779C-2656-4EED-A724-0B04F8F6D0F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E281779C-2656-4EED-A724-0B04F8F6D0F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85DF5F0D-9B07-497D-9626-FE871E7D0696}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85DF5F0D-9B07-497D-9626-FE871E7D0696}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85DF5F0D-9B07-497D-9626-FE871E7D0696}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85DF5F0D-9B07-497D-9626-FE871E7D0696}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{74FB902B-8258-403A-AF21-B0BE144AF8EC} = {0759AA78-9851-423A-9ABF-7022615B85E2}
+		{E281779C-2656-4EED-A724-0B04F8F6D0F1} = {74FB902B-8258-403A-AF21-B0BE144AF8EC}
 	EndGlobalSection
 EndGlobal

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,25 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
-COPY ["src/BabelBot.Receiver.Telegram/BabelBot.Receiver.Telegram.csproj", "BabelBot.Receiver.Telegram/"]
-RUN dotnet restore "BabelBot.Receiver.Telegram/BabelBot.Receiver.Telegram.csproj"
-
 COPY ["src/BabelBot.Shared/BabelBot.Shared.csproj", "BabelBot.Shared/"]
 RUN dotnet restore "BabelBot.Shared/BabelBot.Shared.csproj"
+
+COPY ["src/BabelBot.Receiver.Commands/BabelBot.Receiver.Commands.csproj", "BabelBot.Receiver.Commands/"]
+RUN dotnet restore "BabelBot.Receiver.Commands/BabelBot.Receiver.Commands.csproj"
 
 COPY ["src/BabelBot.Translator.DeepL/BabelBot.Translator.DeepL.csproj", "BabelBot.Translator.DeepL/"]
 RUN dotnet restore "BabelBot.Translator.DeepL/BabelBot.Translator.DeepL.csproj"
 
+COPY ["src/BabelBot.Receiver.Telegram/BabelBot.Receiver.Telegram.csproj", "BabelBot.Receiver.Telegram/"]
+RUN dotnet restore "BabelBot.Receiver.Telegram/BabelBot.Receiver.Telegram.csproj"
+
 COPY ["src/BabelBot.Worker/BabelBot.Worker.csproj", "BabelBot.Worker/"]
 RUN dotnet restore "BabelBot.Worker/BabelBot.Worker.csproj"
 
-COPY ["src/BabelBot.Receiver.Telegram/", "BabelBot.Receiver.Telegram/"]
 COPY ["src/BabelBot.Shared/", "BabelBot.Shared/"]
+COPY ["src/BabelBot.Receiver.Commands/", "BabelBot.Receiver.Commands/"]
 COPY ["src/BabelBot.Translator.DeepL/", "BabelBot.Translator.DeepL/"]
+COPY ["src/BabelBot.Receiver.Telegram/", "BabelBot.Receiver.Telegram/"]
 COPY ["src/BabelBot.Worker/", "BabelBot.Worker/"]
 
 WORKDIR "/src/BabelBot.Worker"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN dotnet restore "BabelBot.Receiver.Commands/BabelBot.Receiver.Commands.csproj
 COPY ["src/BabelBot.Translator.DeepL/BabelBot.Translator.DeepL.csproj", "BabelBot.Translator.DeepL/"]
 RUN dotnet restore "BabelBot.Translator.DeepL/BabelBot.Translator.DeepL.csproj"
 
+COPY ["src/BabelBot.Storage/BabelBot.Storage.csproj", "BabelBot.Storage/"]
+RUN dotnet restore "BabelBot.Storage/BabelBot.Storage.csproj"
+
 COPY ["src/BabelBot.Receiver.Telegram/BabelBot.Receiver.Telegram.csproj", "BabelBot.Receiver.Telegram/"]
 RUN dotnet restore "BabelBot.Receiver.Telegram/BabelBot.Receiver.Telegram.csproj"
 
@@ -22,6 +25,7 @@ RUN dotnet restore "BabelBot.Worker/BabelBot.Worker.csproj"
 COPY ["src/BabelBot.Shared/", "BabelBot.Shared/"]
 COPY ["src/BabelBot.Receiver.Commands/", "BabelBot.Receiver.Commands/"]
 COPY ["src/BabelBot.Translator.DeepL/", "BabelBot.Translator.DeepL/"]
+COPY ["src/BabelBot.Storage/", "BabelBot.Storage/"]
 COPY ["src/BabelBot.Receiver.Telegram/", "BabelBot.Receiver.Telegram/"]
 COPY ["src/BabelBot.Worker/", "BabelBot.Worker/"]
 

--- a/src/BabelBot.Receiver.Commands/BabelBot.Receiver.Commands.csproj
+++ b/src/BabelBot.Receiver.Commands/BabelBot.Receiver.Commands.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BabelBot.Shared\BabelBot.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/BabelBot.Receiver.Commands/BabelBot.Receiver.Commands.csproj
+++ b/src/BabelBot.Receiver.Commands/BabelBot.Receiver.Commands.csproj
@@ -10,4 +10,9 @@
     <ProjectReference Include="..\BabelBot.Shared\BabelBot.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/BabelBot.Receiver.Commands/CommandFactory.cs
+++ b/src/BabelBot.Receiver.Commands/CommandFactory.cs
@@ -1,0 +1,38 @@
+using System.Text.RegularExpressions;
+using BabelBot.Shared.Commands;
+
+namespace BabelBot.Receiver.Commands;
+
+public class CommandFactory : ICommandFactory
+{
+    private static readonly Regex CommandExpression = new Regex("\\/(?<command>[a-z]+)(?: .*?)?$");
+    private IEnumerable<ICommand> _commands;
+
+    public CommandFactory(IEnumerable<ICommand> commands) => _commands = commands;
+
+    public ICommand GetCommand(string message)
+    {
+        var keyword = ExtractCommandKeyword(message);
+        if (keyword is null)
+        {
+            return _commands.FirstOrDefault(cmd => cmd.IsDefault) ?? throw new NoDefaultCommandException();
+        }
+
+        var command = _commands.FirstOrDefault(cmd => cmd.Keyword == keyword);
+
+        if (command is null)
+        {
+            return new MissingCommand(keyword);
+        }
+
+        return command!;
+    }
+
+    private string? ExtractCommandKeyword(string message)
+    {
+        var match = CommandExpression.Match(message);
+        var command = match?.Groups["command"]?.Value;
+
+        return command != string.Empty ? command : null;
+    }
+}

--- a/src/BabelBot.Receiver.Commands/Commands/AddUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/AddUsersCommand.cs
@@ -31,7 +31,7 @@ public class AddUsersCommand : Command
 
         return Task.FromResult(new CommandResult()
         {
-            SuccessMessage = $"The following ids were successfully added: {string.Join(", ", ids)}"
+            SuccessMessage = $"The following ids can now receive translations: {string.Join(", ", ids)}"
         });
     }
 }

--- a/src/BabelBot.Receiver.Commands/Commands/AddUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/AddUsersCommand.cs
@@ -4,21 +4,18 @@ using BabelBot.Shared.Storage;
 
 namespace BabelBot.Receiver.Commands;
 
-public class AddUsersCommand : ICommand
+public class AddUsersCommand : Command
 {
-    public bool IsDefault => false;
-    public string Keyword => "addusers";
+    public override string Keyword => "addusers";
 
     private IUsers _users { get; }
 
     public AddUsersCommand(IUsers users) => _users = users;
 
 
-    public Task<CommandResult> Run(CancellationToken _, ReceivedMessage message)
+    public override Task<CommandResult> Run(ReceivedMessage message, IEnumerable<string> arguments, CancellationToken _)
     {
-        var ids = message.Text
-            .Split(' ')
-            .Skip(1)
+        var ids = arguments
             .Select(id => long.TryParse(id, out var parsed) ? parsed : 0)
             .Where(id => id > 0);
 

--- a/src/BabelBot.Receiver.Commands/Commands/AddUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/AddUsersCommand.cs
@@ -12,6 +12,8 @@ public class AddUsersCommand : Command
     }
 
     public override string Keyword => "addusers";
+    public override string Description =>
+        @$"Add one or more users to the list of users BabelBot translates for: ""/{Keyword} <id1> <id2>"".";
 
     public override IEnumerable<UserRole> AllowedRoles => new[] { UserRole.Superuser };
 

--- a/src/BabelBot.Receiver.Commands/Commands/AddUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/AddUsersCommand.cs
@@ -1,0 +1,38 @@
+using BabelBot.Shared.Commands;
+using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Storage;
+
+namespace BabelBot.Receiver.Commands;
+
+public class AddUsersCommand : ICommand
+{
+    public bool IsDefault => false;
+    public string Keyword => "addusers";
+
+    private IUsers _users { get; }
+
+    public AddUsersCommand(IUsers users) => _users = users;
+
+
+    public Task<CommandResult> Run(CancellationToken _, ReceivedMessage message)
+    {
+        var ids = message.Text
+            .Split(' ')
+            .Skip(1)
+            .Select(id => long.TryParse(id, out var parsed) ? parsed : 0)
+            .Where(id => id > 0);
+
+        if (!ids.Any())
+        {
+            return Task.FromResult(
+                new CommandResult(@$"Please provide at least one Telegram user id: ""/{Keyword} <id1> [...<idN>]"" "));
+        }
+
+        _users.AddUsers(ids);
+
+        return Task.FromResult(new CommandResult()
+        {
+            SuccessMessage = $"The following ids were successfully added: {string.Join(", ", ids)}"
+        });
+    }
+}

--- a/src/BabelBot.Receiver.Commands/Commands/AddUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/AddUsersCommand.cs
@@ -1,17 +1,19 @@
 using BabelBot.Shared.Commands;
 using BabelBot.Shared.Messenger;
 using BabelBot.Shared.Storage;
+using Microsoft.Extensions.Logging;
 
 namespace BabelBot.Receiver.Commands;
 
 public class AddUsersCommand : Command
 {
+    public AddUsersCommand(ILogger<AddUsersCommand> logger, IUsers users) : base(logger, users)
+    {
+    }
+
     public override string Keyword => "addusers";
 
-    private IUsers _users { get; }
-
-    public AddUsersCommand(IUsers users) => _users = users;
-
+    public override IEnumerable<UserRole> AllowedRoles => new[] { UserRole.Superuser };
 
     public override Task<CommandResult> Run(ReceivedMessage message, IEnumerable<string> arguments, CancellationToken _)
     {
@@ -25,7 +27,7 @@ public class AddUsersCommand : Command
                 new CommandResult(@$"Please provide at least one Telegram user id: ""/{Keyword} <id1> [...<idN>]"" "));
         }
 
-        _users.AddUsers(ids);
+        _users.AddTranslationUsers(ids);
 
         return Task.FromResult(new CommandResult()
         {

--- a/src/BabelBot.Receiver.Commands/Commands/Command.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/Command.cs
@@ -18,6 +18,7 @@ public abstract class Command : ICommand
     }
     public virtual bool IsDefault { get; } = false;
     public abstract string Keyword { get; }
+    public abstract string Description { get; }
     public abstract IEnumerable<UserRole> AllowedRoles { get; }
 
     public Task<CommandResult> Run(ReceivedMessage message, CancellationToken cancellationToken)

--- a/src/BabelBot.Receiver.Commands/Commands/Command.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/Command.cs
@@ -1,17 +1,41 @@
 using System.Text.RegularExpressions;
 using BabelBot.Shared.Commands;
 using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Storage;
+using Microsoft.Extensions.Logging;
 
 namespace BabelBot.Receiver.Commands;
 
 public abstract class Command : ICommand
 {
+    protected readonly ILogger<Command> _logger;
+    protected readonly IUsers _users;
+
+    public Command(ILogger<Command> logger, IUsers users)
+    {
+        _logger = logger;
+        _users = users;
+    }
     public virtual bool IsDefault { get; } = false;
     public abstract string Keyword { get; }
+    public abstract IEnumerable<UserRole> AllowedRoles { get; }
 
     public Task<CommandResult> Run(ReceivedMessage message, CancellationToken cancellationToken)
     {
-        var commandPattern = new Regex($"^/{this.Keyword}");
+        if (message.UserId is null)
+        {
+            _logger.LogDebug("Ignored command {Command} because sender is not a user.", Keyword);
+            return Task.FromResult(new CommandResult()); // fail silently
+        }
+
+        var user = _users.GetUser(message.UserId.Value) ?? new User { Role = UserRole.Anonymous };
+        if (!AllowedRoles.Contains(user.Role))
+        {
+            _logger.LogDebug("Ignored command {Command} because sender does not have sufficient permissions.", Keyword);
+            return Task.FromResult(new CommandResult()); // fail silently
+        }
+
+        var commandPattern = new Regex($"^/{this.Keyword} ");
         var arguments = commandPattern.Replace(message.Text, "").Split(' ');
 
         return Run(message, arguments, cancellationToken);

--- a/src/BabelBot.Receiver.Commands/Commands/Command.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/Command.cs
@@ -1,0 +1,21 @@
+using System.Text.RegularExpressions;
+using BabelBot.Shared.Commands;
+using BabelBot.Shared.Messenger;
+
+namespace BabelBot.Receiver.Commands;
+
+public abstract class Command : ICommand
+{
+    public virtual bool IsDefault { get; } = false;
+    public abstract string Keyword { get; }
+
+    public Task<CommandResult> Run(ReceivedMessage message, CancellationToken cancellationToken)
+    {
+        var commandPattern = new Regex($"^/{this.Keyword}");
+        var arguments = commandPattern.Replace(message.Text, "").Split(' ');
+
+        return Run(message, arguments, cancellationToken);
+    }
+
+    public abstract Task<CommandResult> Run(ReceivedMessage message, IEnumerable<string> commandArguments, CancellationToken cancellationToken);
+}

--- a/src/BabelBot.Receiver.Commands/Commands/DeleteUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/DeleteUsersCommand.cs
@@ -1,24 +1,13 @@
 using BabelBot.Shared.Commands;
 using BabelBot.Shared.Messenger;
-using BabelBot.Shared.Options;
 using BabelBot.Shared.Storage;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace BabelBot.Receiver.Commands;
 
 public class DeleteUsersCommand : Command
 {
-    private readonly TelegramOptions _telegramOptions;
-
-    public DeleteUsersCommand(
-        ILogger<DeleteUsersCommand> logger,
-        IUsers users,
-        IOptions<TelegramOptions> telegramOptions)
-        : base(logger, users)
-    {
-        _telegramOptions = telegramOptions.Value;
-    }
+    public DeleteUsersCommand(ILogger<DeleteUsersCommand> logger, IUsers users) : base(logger, users) { }
 
     public override string Keyword => "deleteusers";
     public override string Description =>

--- a/src/BabelBot.Receiver.Commands/Commands/DeleteUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/DeleteUsersCommand.cs
@@ -21,6 +21,8 @@ public class DeleteUsersCommand : Command
     }
 
     public override string Keyword => "deleteusers";
+    public override string Description =>
+        $@"Remove one or more users from the list of users BabelBot translates for: ""/{Keyword} <id1> <id2>"".";
 
     public override IEnumerable<UserRole> AllowedRoles => new[] { UserRole.Superuser };
 

--- a/src/BabelBot.Receiver.Commands/Commands/DeleteUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/DeleteUsersCommand.cs
@@ -1,0 +1,35 @@
+using BabelBot.Shared.Commands;
+using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Storage;
+
+namespace BabelBot.Receiver.Commands;
+
+public class DeleteUsersCommand : Command
+{
+    public override string Keyword => "deleteusers";
+
+    private IUsers _users { get; }
+
+    public DeleteUsersCommand(IUsers users) => _users = users;
+
+
+    public override Task<CommandResult> Run(ReceivedMessage message, IEnumerable<string> arguments, CancellationToken _)
+    {
+        var ids = arguments
+            .Select(id => long.TryParse(id, out var parsed) ? parsed : 0)
+            .Where(id => id > 0);
+
+        if (!ids.Any())
+        {
+            return Task.FromResult(
+                new CommandResult(@$"Please provide at least one Telegram user id: ""/{Keyword} <id1> [...<idN>]"" "));
+        }
+
+        _users.DeleteUsers(ids);
+
+        return Task.FromResult(new CommandResult()
+        {
+            SuccessMessage = $"The following ids were successfully deleted: {string.Join(", ", ids)}"
+        });
+    }
+}

--- a/src/BabelBot.Receiver.Commands/Commands/DeleteUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/DeleteUsersCommand.cs
@@ -42,7 +42,7 @@ public class DeleteUsersCommand : Command
 
         return Task.FromResult(new CommandResult()
         {
-            SuccessMessage = $"The following ids were successfully deleted: {string.Join(", ", ids)}"
+            SuccessMessage = $"The following ids will no longer receive translations: {string.Join(", ", ids)}"
         });
     }
 }

--- a/src/BabelBot.Receiver.Commands/Commands/ListUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/ListUsersCommand.cs
@@ -19,6 +19,6 @@ public class ListUsersCommand : Command
     {
         var users = _users.GetList().Select(user => user.Id);
 
-        return Task.FromResult(new CommandResult($"Registered users: {string.Join(", ", users)}"));
+        return Task.FromResult(new CommandResult($"Registered users that can receive translations: {string.Join(", ", users)}"));
     }
 }

--- a/src/BabelBot.Receiver.Commands/Commands/ListUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/ListUsersCommand.cs
@@ -1,21 +1,23 @@
 using BabelBot.Shared.Commands;
 using BabelBot.Shared.Messenger;
 using BabelBot.Shared.Storage;
+using Microsoft.Extensions.Logging;
 
 namespace BabelBot.Receiver.Commands;
 
 public class ListUsersCommand : Command
 {
+    public ListUsersCommand(ILogger<ListUsersCommand> logger, IUsers users) : base(logger, users)
+    {
+    }
+
     public override string Keyword => "listusers";
 
-    private IUsers _users { get; }
-
-    public ListUsersCommand(IUsers users) => _users = users;
-
+    public override IEnumerable<UserRole> AllowedRoles => new[] { UserRole.Superuser };
 
     public override Task<CommandResult> Run(ReceivedMessage _message, IEnumerable<string> _arguments, CancellationToken _)
     {
-        var users = _users.GetList();
+        var users = _users.GetList().Select(user => user.Id);
 
         return Task.FromResult(new CommandResult($"Registered users: {string.Join(", ", users)}"));
     }

--- a/src/BabelBot.Receiver.Commands/Commands/ListUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/ListUsersCommand.cs
@@ -1,0 +1,23 @@
+using BabelBot.Shared.Commands;
+using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Storage;
+
+namespace BabelBot.Receiver.Commands;
+
+public class ListUsersCommand : ICommand
+{
+    public bool IsDefault => false;
+    public string Keyword => "listusers";
+
+    private IUsers _users { get; }
+
+    public ListUsersCommand(IUsers users) => _users = users;
+
+
+    public Task<CommandResult> Run(CancellationToken _token, ReceivedMessage _message)
+    {
+        var users = _users.GetList();
+
+        return Task.FromResult(new CommandResult($"Registered users: {string.Join(", ", users)}"));
+    }
+}

--- a/src/BabelBot.Receiver.Commands/Commands/ListUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/ListUsersCommand.cs
@@ -4,17 +4,16 @@ using BabelBot.Shared.Storage;
 
 namespace BabelBot.Receiver.Commands;
 
-public class ListUsersCommand : ICommand
+public class ListUsersCommand : Command
 {
-    public bool IsDefault => false;
-    public string Keyword => "listusers";
+    public override string Keyword => "listusers";
 
     private IUsers _users { get; }
 
     public ListUsersCommand(IUsers users) => _users = users;
 
 
-    public Task<CommandResult> Run(CancellationToken _token, ReceivedMessage _message)
+    public override Task<CommandResult> Run(ReceivedMessage _message, IEnumerable<string> _arguments, CancellationToken _)
     {
         var users = _users.GetList();
 

--- a/src/BabelBot.Receiver.Commands/Commands/ListUsersCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/ListUsersCommand.cs
@@ -12,6 +12,8 @@ public class ListUsersCommand : Command
     }
 
     public override string Keyword => "listusers";
+    public override string Description =>
+        $@"List users who BabelBot translates for: ""/{Keyword}"".";
 
     public override IEnumerable<UserRole> AllowedRoles => new[] { UserRole.Superuser };
 

--- a/src/BabelBot.Receiver.Commands/Commands/TranslateCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/TranslateCommand.cs
@@ -4,10 +4,10 @@ using BabelBot.Shared.Translation;
 
 namespace BabelBot.Receiver.Commands;
 
-public class TranslateCommand : ICommand
+public class TranslateCommand : Command
 {
-    public bool IsDefault => true;
-    public string Keyword => "";
+    public override bool IsDefault => true;
+    public override string Keyword => "";
 
     private ITranslator _translator { get; }
     private IMessenger _messenger { get; }
@@ -19,7 +19,10 @@ public class TranslateCommand : ICommand
     }
 
 
-    public async Task<CommandResult> Run(CancellationToken cancellationToken, ReceivedMessage message)
+    public override async Task<CommandResult> Run(
+        ReceivedMessage message,
+        IEnumerable<string> _arguments,
+        CancellationToken cancellationToken)
     {
         var translatedText = await _translator.TranslateAsync(message.Text, cancellationToken);
 

--- a/src/BabelBot.Receiver.Commands/Commands/TranslateCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/TranslateCommand.cs
@@ -1,0 +1,60 @@
+using BabelBot.Shared.Commands;
+using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Translation;
+
+namespace BabelBot.Receiver.Commands;
+
+public class TranslateCommand : ICommand
+{
+    public bool IsDefault => true;
+    public string Keyword => "";
+
+    private ITranslator _translator { get; }
+    private IMessenger _messenger { get; }
+
+    public TranslateCommand(ITranslator translator, IMessenger messenger)
+    {
+        _translator = translator;
+        _messenger = messenger;
+    }
+
+
+    public async Task<CommandResult> Run(CancellationToken cancellationToken, ReceivedMessage message)
+    {
+        var translatedText = await _translator.TranslateAsync(message.Text, cancellationToken);
+
+        foreach (var part in SplitTranslationResult(translatedText))
+        {
+            await _messenger.SendTextMessage(
+                chatId: message.ChatId,
+                text: part,
+                replyToMessageId: message.Id,
+                cancellationToken: cancellationToken);
+        }
+
+        return new CommandResult();
+    }
+
+    private static IEnumerable<string> SplitTranslationResult(TranslationResult translatedText)
+    {
+        const int maxPartLength = 4096;
+        const int maxParts = 99;
+
+        var length = translatedText.Text.Length;
+
+        if (length < maxPartLength)
+        {
+            yield return translatedText.Text;
+            yield break;
+        }
+
+        const int chunkSize = maxPartLength - 10;
+        var totalParts = Math.Min(maxParts, (int)Math.Ceiling((double)length / chunkSize));
+        for (int i = 0, c = 1; i < length && c < maxParts; i += chunkSize)
+        {
+            yield return
+                $"[{c}/{totalParts}]\n\n{translatedText.Text.Substring(i, Math.Min(chunkSize, length - i))}";
+            c++;
+        }
+    }
+}

--- a/src/BabelBot.Receiver.Commands/Commands/TranslateCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/TranslateCommand.cs
@@ -58,6 +58,7 @@ public class TranslateCommand : Command
 
     private static IEnumerable<string> SplitTranslationResult(TranslationResult translatedText)
     {
+        // FIXME: 4096 is the maximum length for Telegram messages and should not be set here
         const int maxPartLength = 4096;
         const int maxParts = 99;
 

--- a/src/BabelBot.Receiver.Commands/Commands/TranslateCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/TranslateCommand.cs
@@ -11,7 +11,8 @@ namespace BabelBot.Receiver.Commands;
 public class TranslateCommand : Command
 {
     public override bool IsDefault => true;
-    public override string Keyword => "";
+    public override string Keyword => string.Empty;
+    public override string Description => string.Empty;
 
     public override IEnumerable<UserRole> AllowedRoles => _telegramOptions.OnlyReactToAllowedUsers
         ? new[] { UserRole.TranslationUser, UserRole.Superuser }

--- a/src/BabelBot.Receiver.Commands/Commands/TranslateCommand.cs
+++ b/src/BabelBot.Receiver.Commands/Commands/TranslateCommand.cs
@@ -1,6 +1,10 @@
 using BabelBot.Shared.Commands;
 using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Options;
+using BabelBot.Shared.Storage;
 using BabelBot.Shared.Translation;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BabelBot.Receiver.Commands;
 
@@ -9,13 +13,26 @@ public class TranslateCommand : Command
     public override bool IsDefault => true;
     public override string Keyword => "";
 
+    public override IEnumerable<UserRole> AllowedRoles => _telegramOptions.OnlyReactToAllowedUsers
+        ? new[] { UserRole.TranslationUser, UserRole.Superuser }
+        : Enum.GetValues<UserRole>();
+
     private ITranslator _translator { get; }
     private IMessenger _messenger { get; }
+    private readonly TelegramOptions _telegramOptions;
 
-    public TranslateCommand(ITranslator translator, IMessenger messenger)
+
+    public TranslateCommand(
+        ILogger<TranslateCommand> logger,
+        IUsers users,
+        ITranslator translator,
+        IMessenger messenger,
+        IOptions<TelegramOptions> telegramOptions)
+        : base(logger, users)
     {
         _translator = translator;
         _messenger = messenger;
+        _telegramOptions = telegramOptions.Value;
     }
 
 

--- a/src/BabelBot.Receiver.Commands/Exceptions/NoDefaultCommandException.cs
+++ b/src/BabelBot.Receiver.Commands/Exceptions/NoDefaultCommandException.cs
@@ -1,0 +1,6 @@
+namespace BabelBot.Receiver.Commands;
+
+public class NoDefaultCommandException : Exception
+{
+    public NoDefaultCommandException() : base("No default command set up") { }
+}

--- a/src/BabelBot.Receiver.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BabelBot.Receiver.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -8,8 +8,9 @@ public static class ServiceCollectionExtension
     public static void AddCommands(this IServiceCollection collection)
     {
         collection.AddSingleton<ICommandFactory, CommandFactory>();
-        collection.AddSingleton<ICommand, AddUsersCommand>();
         collection.AddSingleton<ICommand, ListUsersCommand>();
+        collection.AddSingleton<ICommand, AddUsersCommand>();
+        collection.AddSingleton<ICommand, DeleteUsersCommand>();
         collection.AddSingleton<ICommand, TranslateCommand>();
     }
 }

--- a/src/BabelBot.Receiver.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BabelBot.Receiver.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,8 @@ public static class ServiceCollectionExtension
     public static void AddCommands(this IServiceCollection collection)
     {
         collection.AddSingleton<ICommandFactory, CommandFactory>();
+        collection.AddSingleton<ICommand, AddUsersCommand>();
+        collection.AddSingleton<ICommand, ListUsersCommand>();
         collection.AddSingleton<ICommand, TranslateCommand>();
     }
 }

--- a/src/BabelBot.Receiver.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BabelBot.Receiver.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using BabelBot.Shared.Commands;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BabelBot.Receiver.Commands;
+
+public static class ServiceCollectionExtension
+{
+    public static void AddCommands(this IServiceCollection collection)
+    {
+        collection.AddSingleton<ICommandFactory, CommandFactory>();
+        collection.AddSingleton<ICommand, TranslateCommand>();
+    }
+}

--- a/src/BabelBot.Receiver.Telegram/CommandRegistrator.cs
+++ b/src/BabelBot.Receiver.Telegram/CommandRegistrator.cs
@@ -1,0 +1,26 @@
+using BabelBot.Shared.Commands;
+using BabelBot.Shared.Messenger;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+
+namespace BabelBot.Receiver.Telegram;
+
+public class CommandRegistrator : ICommandRegistrator
+{
+    ITelegramBotClient _botClient;
+    IEnumerable<ICommand> _commands;
+
+    public CommandRegistrator(ITelegramBotClient botClient, IEnumerable<ICommand> commands)
+    {
+        _botClient = botClient;
+        _commands = commands;
+    }
+
+    public async Task RegisterCommands(CancellationToken cancellationToken)
+    {
+        var commands = _commands
+            .Where(command => !string.IsNullOrEmpty(command.Keyword))
+            .Select(command => new BotCommand { Command = command.Keyword, Description = command.Description });
+        await _botClient.SetMyCommandsAsync(commands, cancellationToken: cancellationToken);
+    }
+}

--- a/src/BabelBot.Receiver.Telegram/Extensions/ServiceCollectionExtension.cs
+++ b/src/BabelBot.Receiver.Telegram/Extensions/ServiceCollectionExtension.cs
@@ -11,8 +11,9 @@ public static class ServiceCollectionExtension
 {
     public static void AddTelegramReceiver(this IServiceCollection collection, IConfiguration configurationSection)
     {
-        collection.AddSingleton<TelegramReceiver>();
+        collection.AddSingleton<ICommandRegistrator, CommandRegistrator>();
         collection.AddSingleton<IMessenger, TelegramMessenger>();
+        collection.AddSingleton<TelegramReceiver>();
         collection.AddSingleton<ITelegramBotClient, TelegramBotClient>((services) =>
             new TelegramBotClient(services.GetService<IOptions<TelegramOptions>>()!.Value.ApiKey));
 

--- a/src/BabelBot.Receiver.Telegram/Extensions/ServiceCollectionExtension.cs
+++ b/src/BabelBot.Receiver.Telegram/Extensions/ServiceCollectionExtension.cs
@@ -1,5 +1,9 @@
+using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Telegram.Bot;
 
 namespace BabelBot.Receiver.Telegram.Extensions;
 
@@ -8,6 +12,10 @@ public static class ServiceCollectionExtension
     public static void AddTelegramReceiver(this IServiceCollection collection, IConfiguration configurationSection)
     {
         collection.AddSingleton<TelegramReceiver>();
+        collection.AddSingleton<IMessenger, TelegramMessenger>();
+        collection.AddSingleton<ITelegramBotClient, TelegramBotClient>((services) =>
+            new TelegramBotClient(services.GetService<IOptions<TelegramOptions>>()!.Value.ApiKey));
+
         collection.Configure<TelegramOptions>(configurationSection);
     }
 }

--- a/src/BabelBot.Receiver.Telegram/TelegramMessenger.cs
+++ b/src/BabelBot.Receiver.Telegram/TelegramMessenger.cs
@@ -1,0 +1,23 @@
+using BabelBot.Shared.Messenger;
+using Telegram.Bot;
+
+namespace BabelBot.Receiver.Telegram;
+
+public class TelegramMessenger : IMessenger
+{
+    private ITelegramBotClient _botClient;
+
+    public TelegramMessenger(ITelegramBotClient botClient)
+    {
+        _botClient = botClient;
+    }
+
+    public async Task SendTextMessage(long chatId, string text, int? replyToMessageId, CancellationToken cancellationToken = default)
+    {
+        await _botClient.SendTextMessageAsync(
+            chatId: chatId,
+            text: text,
+            replyToMessageId: replyToMessageId,
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/BabelBot.Receiver.Telegram/TelegramReceiver.cs
+++ b/src/BabelBot.Receiver.Telegram/TelegramReceiver.cs
@@ -97,7 +97,7 @@ public class TelegramReceiver : IReceiver
         }
 
         var message = new ReceivedMessage { ChatId = chatId, Id = messageId, Text = sourceText };
-        var result = await command.Run(cancellationToken, message);
+        var result = await command.Run(message, cancellationToken);
 
         if (result.HasError)
         {

--- a/src/BabelBot.Receiver.Telegram/TelegramReceiver.cs
+++ b/src/BabelBot.Receiver.Telegram/TelegramReceiver.cs
@@ -1,7 +1,6 @@
 ﻿using BabelBot.Shared.Commands;
 using BabelBot.Shared.Messenger;
 using BabelBot.Shared.Options;
-using BabelBot.Shared.Storage;
 using BabelBot.Shared.Translation;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/BabelBot.Shared/Commands/CommandResult.cs
+++ b/src/BabelBot.Shared/Commands/CommandResult.cs
@@ -1,0 +1,15 @@
+namespace BabelBot.Shared.Commands;
+
+public class CommandResult
+{
+    public CommandResult() => Error = null;
+
+    public CommandResult(string error) => Error = error;
+    public string? Error { get; private set; }
+
+    public bool Success => Error == null;
+
+    public string? SuccessMessage { get; init; } = null;
+
+    public bool HasError => !Success;
+}

--- a/src/BabelBot.Shared/Commands/ICommand.cs
+++ b/src/BabelBot.Shared/Commands/ICommand.cs
@@ -7,6 +7,7 @@ public interface ICommand
 {
     bool IsDefault { get; }
     string Keyword { get; }
+    string Description { get; }
     IEnumerable<UserRole> AllowedRoles { get; }
     Task<CommandResult> Run(ReceivedMessage message, CancellationToken cancellationToken);
 }

--- a/src/BabelBot.Shared/Commands/ICommand.cs
+++ b/src/BabelBot.Shared/Commands/ICommand.cs
@@ -1,4 +1,5 @@
 ﻿using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Storage;
 
 namespace BabelBot.Shared.Commands;
 
@@ -6,5 +7,6 @@ public interface ICommand
 {
     bool IsDefault { get; }
     string Keyword { get; }
+    IEnumerable<UserRole> AllowedRoles { get; }
     Task<CommandResult> Run(ReceivedMessage message, CancellationToken cancellationToken);
 }

--- a/src/BabelBot.Shared/Commands/ICommand.cs
+++ b/src/BabelBot.Shared/Commands/ICommand.cs
@@ -6,5 +6,5 @@ public interface ICommand
 {
     bool IsDefault { get; }
     string Keyword { get; }
-    Task<CommandResult> Run(CancellationToken cancellationToken, ReceivedMessage message);
+    Task<CommandResult> Run(ReceivedMessage message, CancellationToken cancellationToken);
 }

--- a/src/BabelBot.Shared/Commands/ICommand.cs
+++ b/src/BabelBot.Shared/Commands/ICommand.cs
@@ -1,0 +1,10 @@
+﻿using BabelBot.Shared.Messenger;
+
+namespace BabelBot.Shared.Commands;
+
+public interface ICommand
+{
+    bool IsDefault { get; }
+    string Keyword { get; }
+    Task<CommandResult> Run(CancellationToken cancellationToken, ReceivedMessage message);
+}

--- a/src/BabelBot.Shared/Commands/ICommandFactory.cs
+++ b/src/BabelBot.Shared/Commands/ICommandFactory.cs
@@ -1,0 +1,6 @@
+namespace BabelBot.Shared.Commands;
+
+public interface ICommandFactory
+{
+    ICommand GetCommand(string message);
+}

--- a/src/BabelBot.Shared/Commands/MissingCommand.cs
+++ b/src/BabelBot.Shared/Commands/MissingCommand.cs
@@ -1,4 +1,5 @@
 using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Storage;
 
 namespace BabelBot.Shared.Commands
 {
@@ -10,6 +11,8 @@ namespace BabelBot.Shared.Commands
         public string Keyword { get; }
 
         public bool IsDefault => false;
+
+        public IEnumerable<UserRole> AllowedRoles => Enum.GetValues<UserRole>();
 
         public MissingCommand(string keyword)
         {

--- a/src/BabelBot.Shared/Commands/MissingCommand.cs
+++ b/src/BabelBot.Shared/Commands/MissingCommand.cs
@@ -1,0 +1,24 @@
+using BabelBot.Shared.Messenger;
+
+namespace BabelBot.Shared.Commands
+{
+    /// <summary>
+    /// Special command placeholder for unknown commands
+    /// </summary>
+    public class MissingCommand : ICommand
+    {
+        public string Keyword { get; }
+
+        public bool IsDefault => false;
+
+        public MissingCommand(string keyword)
+        {
+            Keyword = keyword;
+        }
+
+        public Task<CommandResult> Run(CancellationToken _token, ReceivedMessage _message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/BabelBot.Shared/Commands/MissingCommand.cs
+++ b/src/BabelBot.Shared/Commands/MissingCommand.cs
@@ -9,6 +9,7 @@ namespace BabelBot.Shared.Commands
     public class MissingCommand : ICommand
     {
         public string Keyword { get; }
+        public string Description => string.Empty;
 
         public bool IsDefault => false;
 

--- a/src/BabelBot.Shared/Commands/MissingCommand.cs
+++ b/src/BabelBot.Shared/Commands/MissingCommand.cs
@@ -16,7 +16,7 @@ namespace BabelBot.Shared.Commands
             Keyword = keyword;
         }
 
-        public Task<CommandResult> Run(CancellationToken _token, ReceivedMessage _message)
+        public Task<CommandResult> Run(ReceivedMessage _message, CancellationToken _token)
         {
             throw new NotImplementedException();
         }

--- a/src/BabelBot.Shared/IReceiverSettings.cs
+++ b/src/BabelBot.Shared/IReceiverSettings.cs
@@ -1,5 +1,0 @@
-namespace BabelBot.Shared;
-
-public interface IReceiverSettings
-{
-}

--- a/src/BabelBot.Shared/Messenger/ICommandRegistrator.cs
+++ b/src/BabelBot.Shared/Messenger/ICommandRegistrator.cs
@@ -1,0 +1,6 @@
+namespace BabelBot.Shared.Messenger;
+
+public interface ICommandRegistrator
+{
+    Task RegisterCommands(CancellationToken cancellationToken);
+}

--- a/src/BabelBot.Shared/Messenger/IMessenger.cs
+++ b/src/BabelBot.Shared/Messenger/IMessenger.cs
@@ -1,0 +1,6 @@
+namespace BabelBot.Shared.Messenger;
+
+public interface IMessenger
+{
+    Task SendTextMessage(long chatId, string text, int? replyToMessageId, CancellationToken cancellationToken = default);
+}

--- a/src/BabelBot.Shared/Messenger/IReceiver.cs
+++ b/src/BabelBot.Shared/Messenger/IReceiver.cs
@@ -1,4 +1,4 @@
-﻿namespace BabelBot.Shared;
+﻿namespace BabelBot.Shared.Messenger;
 
 public interface IReceiver
 {

--- a/src/BabelBot.Shared/Messenger/IReceiverSettings.cs
+++ b/src/BabelBot.Shared/Messenger/IReceiverSettings.cs
@@ -1,0 +1,5 @@
+namespace BabelBot.Shared.Messenger;
+
+public interface IReceiverSettings
+{
+}

--- a/src/BabelBot.Shared/Messenger/ReceivedMessage.cs
+++ b/src/BabelBot.Shared/Messenger/ReceivedMessage.cs
@@ -1,0 +1,8 @@
+namespace BabelBot.Shared.Messenger;
+
+public struct ReceivedMessage
+{
+    public int Id { get; set; }
+    public long ChatId { get; set; }
+    public string Text { get; set; }
+}

--- a/src/BabelBot.Shared/Messenger/ReceivedMessage.cs
+++ b/src/BabelBot.Shared/Messenger/ReceivedMessage.cs
@@ -3,6 +3,7 @@ namespace BabelBot.Shared.Messenger;
 public struct ReceivedMessage
 {
     public int Id { get; set; }
+    public long? UserId { get; set; }
     public long ChatId { get; set; }
     public string Text { get; set; }
 }

--- a/src/BabelBot.Shared/Options/TelegramOptions.cs
+++ b/src/BabelBot.Shared/Options/TelegramOptions.cs
@@ -1,6 +1,6 @@
-using BabelBot.Shared;
+using BabelBot.Shared.Messenger;
 
-namespace BabelBot.Receiver.Telegram;
+namespace BabelBot.Shared.Options;
 
 public class TelegramOptions : IReceiverSettings
 {

--- a/src/BabelBot.Shared/Storage/IUsers.cs
+++ b/src/BabelBot.Shared/Storage/IUsers.cs
@@ -1,0 +1,8 @@
+namespace BabelBot.Shared.Storage;
+
+public interface IUsers
+{
+    IEnumerable<long> GetList();
+    void AddUsers(IEnumerable<long> ids);
+    bool IsValidUser(long id);
+}

--- a/src/BabelBot.Shared/Storage/IUsers.cs
+++ b/src/BabelBot.Shared/Storage/IUsers.cs
@@ -2,8 +2,9 @@ namespace BabelBot.Shared.Storage;
 
 public interface IUsers
 {
-    IEnumerable<long> GetList();
-    void AddUsers(IEnumerable<long> ids);
-    void DeleteUsers(IEnumerable<long> ids);
-    bool IsValidUser(long id);
+    IEnumerable<User> GetList();
+    IEnumerable<User> GetList(Func<User, bool> predicate);
+    void AddTranslationUsers(IEnumerable<long> ids);
+    void DeleteTranslationUsers(IEnumerable<long> ids);
+    User? GetUser(long id);
 }

--- a/src/BabelBot.Shared/Storage/IUsers.cs
+++ b/src/BabelBot.Shared/Storage/IUsers.cs
@@ -4,5 +4,6 @@ public interface IUsers
 {
     IEnumerable<long> GetList();
     void AddUsers(IEnumerable<long> ids);
+    void DeleteUsers(IEnumerable<long> ids);
     bool IsValidUser(long id);
 }

--- a/src/BabelBot.Shared/Storage/User.cs
+++ b/src/BabelBot.Shared/Storage/User.cs
@@ -1,0 +1,7 @@
+namespace BabelBot.Shared.Storage;
+
+public class User
+{
+    public long Id { get; set; }
+    public UserRole Role { get; set; }
+}

--- a/src/BabelBot.Shared/Storage/UserRole.cs
+++ b/src/BabelBot.Shared/Storage/UserRole.cs
@@ -1,0 +1,8 @@
+namespace BabelBot.Shared.Storage;
+
+public enum UserRole
+{
+    Anonymous = 0,
+    TranslationUser = 1,
+    Superuser = 2,
+}

--- a/src/BabelBot.Shared/Translation/ITranslator.cs
+++ b/src/BabelBot.Shared/Translation/ITranslator.cs
@@ -1,4 +1,4 @@
-namespace BabelBot.Shared;
+namespace BabelBot.Shared.Translation;
 
 public interface ITranslator
 {

--- a/src/BabelBot.Shared/Translation/TranslationContext.cs
+++ b/src/BabelBot.Shared/Translation/TranslationContext.cs
@@ -1,4 +1,4 @@
-namespace BabelBot.Shared;
+namespace BabelBot.Shared.Translation;
 
 public class TranslationContext
 {

--- a/src/BabelBot.Shared/Translation/TranslationResult.cs
+++ b/src/BabelBot.Shared/Translation/TranslationResult.cs
@@ -1,4 +1,4 @@
-namespace BabelBot.Shared;
+namespace BabelBot.Shared.Translation;
 
 public class TranslationResult
 {

--- a/src/BabelBot.Storage/BabelBot.Storage.csproj
+++ b/src/BabelBot.Storage/BabelBot.Storage.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BabelBot.Shared\BabelBot.Shared.csproj" />
+  </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0"/>
+    </ItemGroup>
+
+</Project>

--- a/src/BabelBot.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BabelBot.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+using BabelBot.Shared.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BabelBot.Storage;
+
+public static class ServiceCollectionExtension
+{
+    public static void AddStorage(this IServiceCollection collection)
+    {
+        collection.AddSingleton<IUsers, Users>();
+    }
+}

--- a/src/BabelBot.Storage/Users.cs
+++ b/src/BabelBot.Storage/Users.cs
@@ -1,0 +1,30 @@
+﻿using BabelBot.Shared.Options;
+using BabelBot.Shared.Storage;
+using Microsoft.Extensions.Options;
+
+namespace BabelBot.Storage;
+
+public class Users : IUsers
+{
+    private List<long> UserIds = new();
+
+    public Users(IOptions<TelegramOptions> telegramOptions)
+    {
+        UserIds.AddRange(telegramOptions.Value.AllowedUsers);
+    }
+
+    public IEnumerable<long> GetList()
+    {
+        return UserIds.AsEnumerable();
+    }
+
+    public bool IsValidUser(long id)
+    {
+        return UserIds.Contains(id);
+    }
+
+    public void AddUsers(IEnumerable<long> ids)
+    {
+        UserIds.AddRange(ids);
+    }
+}

--- a/src/BabelBot.Storage/Users.cs
+++ b/src/BabelBot.Storage/Users.cs
@@ -27,4 +27,9 @@ public class Users : IUsers
     {
         UserIds.AddRange(ids);
     }
+
+    public void DeleteUsers(IEnumerable<long> ids)
+    {
+        UserIds.RemoveAll(id => ids.Contains(id));
+    }
 }

--- a/src/BabelBot.Storage/Users.cs
+++ b/src/BabelBot.Storage/Users.cs
@@ -6,30 +6,38 @@ namespace BabelBot.Storage;
 
 public class Users : IUsers
 {
-    private List<long> UserIds = new();
+    private List<User> UserStorage = new();
 
     public Users(IOptions<TelegramOptions> telegramOptions)
     {
-        UserIds.AddRange(telegramOptions.Value.AllowedUsers);
+        var superusers = telegramOptions.Value.AllowedUsers
+            .Select(id => new User { Id = id, Role = UserRole.Superuser });
+        UserStorage.AddRange(superusers);
     }
 
-    public IEnumerable<long> GetList()
+    public IEnumerable<User> GetList()
     {
-        return UserIds.AsEnumerable();
+        return UserStorage.AsEnumerable();
     }
 
-    public bool IsValidUser(long id)
+    public IEnumerable<User> GetList(Func<User, bool> predicate)
     {
-        return UserIds.Contains(id);
+        return UserStorage.Where(predicate).AsEnumerable();
     }
 
-    public void AddUsers(IEnumerable<long> ids)
+    public User? GetUser(long id)
     {
-        UserIds.AddRange(ids);
+        return UserStorage.FirstOrDefault(user => user.Id == id);
     }
 
-    public void DeleteUsers(IEnumerable<long> ids)
+    public void AddTranslationUsers(IEnumerable<long> ids)
     {
-        UserIds.RemoveAll(id => ids.Contains(id));
+        var users = ids.Select(id => new User { Id = id, Role = UserRole.TranslationUser });
+        UserStorage.AddRange(users);
+    }
+
+    public void DeleteTranslationUsers(IEnumerable<long> ids)
+    {
+        UserStorage.RemoveAll(user => ids.Contains(user.Id));
     }
 }

--- a/src/BabelBot.Storage/Users.cs
+++ b/src/BabelBot.Storage/Users.cs
@@ -6,38 +6,38 @@ namespace BabelBot.Storage;
 
 public class Users : IUsers
 {
-    private List<User> UserStorage = new();
+    private List<User> _userStorage = new();
 
     public Users(IOptions<TelegramOptions> telegramOptions)
     {
         var superusers = telegramOptions.Value.AllowedUsers
             .Select(id => new User { Id = id, Role = UserRole.Superuser });
-        UserStorage.AddRange(superusers);
+        _userStorage.AddRange(superusers);
     }
 
     public IEnumerable<User> GetList()
     {
-        return UserStorage.AsEnumerable();
+        return _userStorage.AsEnumerable();
     }
 
     public IEnumerable<User> GetList(Func<User, bool> predicate)
     {
-        return UserStorage.Where(predicate).AsEnumerable();
+        return _userStorage.Where(predicate).AsEnumerable();
     }
 
     public User? GetUser(long id)
     {
-        return UserStorage.FirstOrDefault(user => user.Id == id);
+        return _userStorage.FirstOrDefault(user => user.Id == id);
     }
 
     public void AddTranslationUsers(IEnumerable<long> ids)
     {
         var users = ids.Select(id => new User { Id = id, Role = UserRole.TranslationUser });
-        UserStorage.AddRange(users);
+        _userStorage.AddRange(users);
     }
 
     public void DeleteTranslationUsers(IEnumerable<long> ids)
     {
-        UserStorage.RemoveAll(user => ids.Contains(user.Id));
+        _userStorage.RemoveAll(user => ids.Contains(user.Id));
     }
 }

--- a/src/BabelBot.Translator.DeepL/DeepLTranslator.cs
+++ b/src/BabelBot.Translator.DeepL/DeepLTranslator.cs
@@ -1,4 +1,4 @@
-﻿using BabelBot.Shared;
+﻿using BabelBot.Shared.Translation;
 using DeepL;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -36,7 +36,7 @@ public class DeepLTranslator : ITranslator
     {
         return TranslateAsync(
             text,
-            new TranslationContext {TargetLanguage = _options.DefaultTargetLanguageCode},
+            new TranslationContext { TargetLanguage = _options.DefaultTargetLanguageCode },
             cancellationToken);
     }
 }

--- a/src/BabelBot.Translator.DeepL/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BabelBot.Translator.DeepL/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-using BabelBot.Shared;
+using BabelBot.Shared.Translation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/BabelBot.Worker/BabelBot.Worker.csproj
+++ b/src/BabelBot.Worker/BabelBot.Worker.csproj
@@ -20,5 +20,6 @@
         <ProjectReference Include="..\BabelBot.Shared\BabelBot.Shared.csproj" />
         <ProjectReference Include="..\BabelBot.Translator.DeepL\BabelBot.Translator.DeepL.csproj" />
         <ProjectReference Include="..\BabelBot.Receiver.Commands\BabelBot.Receiver.Commands.csproj" />
+        <ProjectReference Include="..\BabelBot.Storage\BabelBot.Storage.csproj" />
     </ItemGroup>
 </Project>

--- a/src/BabelBot.Worker/BabelBot.Worker.csproj
+++ b/src/BabelBot.Worker/BabelBot.Worker.csproj
@@ -16,8 +16,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\BabelBot.Receiver.Telegram\BabelBot.Receiver.Telegram.csproj"/>
-        <ProjectReference Include="..\BabelBot.Shared\BabelBot.Shared.csproj"/>
-        <ProjectReference Include="..\BabelBot.Translator.DeepL\BabelBot.Translator.DeepL.csproj"/>
+        <ProjectReference Include="..\BabelBot.Receiver.Telegram\BabelBot.Receiver.Telegram.csproj" />
+        <ProjectReference Include="..\BabelBot.Shared\BabelBot.Shared.csproj" />
+        <ProjectReference Include="..\BabelBot.Translator.DeepL\BabelBot.Translator.DeepL.csproj" />
+        <ProjectReference Include="..\BabelBot.Receiver.Commands\BabelBot.Receiver.Commands.csproj" />
     </ItemGroup>
 </Project>

--- a/src/BabelBot.Worker/Factory/ReceiverFactory.cs
+++ b/src/BabelBot.Worker/Factory/ReceiverFactory.cs
@@ -1,5 +1,5 @@
 using BabelBot.Receiver.Telegram;
-using BabelBot.Shared;
+using BabelBot.Shared.Messenger;
 using Microsoft.Extensions.Options;
 
 namespace BabelBot.Worker.Factory;

--- a/src/BabelBot.Worker/Program.cs
+++ b/src/BabelBot.Worker/Program.cs
@@ -1,5 +1,6 @@
 using BabelBot.Receiver.Commands;
 using BabelBot.Receiver.Telegram.Extensions;
+using BabelBot.Storage;
 using BabelBot.Translator.DeepL.Extensions;
 using BabelBot.Worker.Factory;
 
@@ -31,6 +32,7 @@ class Program
                 }
 
                 services.AddCommands();
+                services.AddStorage();
 
                 services.AddSingleton<ReceiverFactory>();
                 services.AddHostedService<Worker>();

--- a/src/BabelBot.Worker/Program.cs
+++ b/src/BabelBot.Worker/Program.cs
@@ -1,3 +1,4 @@
+using BabelBot.Receiver.Commands;
 using BabelBot.Receiver.Telegram.Extensions;
 using BabelBot.Translator.DeepL.Extensions;
 using BabelBot.Worker.Factory;
@@ -9,14 +10,15 @@ class Program
     private static async Task Main(string[] args)
     {
         var builder = Host.CreateDefaultBuilder(args);
-            
+
         var host = builder.ConfigureServices((hostContext, services) =>
             {
                 var configuration = hostContext.Configuration;
                 var workerOptionsSection = configuration.GetSection(WorkerOptions.SectionKey);
                 services.Configure<WorkerOptions>(workerOptionsSection);
 
-                services.AddTelegramReceiver(configuration.GetSection("Telegram"));
+                var telegramOptions = configuration.GetSection("Telegram");
+                services.AddTelegramReceiver(telegramOptions);
 
                 var translator = workerOptionsSection.GetValue<string>("Translator");
                 switch (translator)
@@ -28,6 +30,8 @@ class Program
                         throw new ArgumentException($"Unknown translator [{translator}]");
                 }
 
+                services.AddCommands();
+
                 services.AddSingleton<ReceiverFactory>();
                 services.AddHostedService<Worker>();
             })
@@ -36,4 +40,3 @@ class Program
         await host.RunAsync();
     }
 }
-

--- a/src/BabelBot.Worker/Worker.cs
+++ b/src/BabelBot.Worker/Worker.cs
@@ -1,5 +1,4 @@
-using System.Reflection;
-using BabelBot.Shared;
+using BabelBot.Shared.Messenger;
 using BabelBot.Worker.Factory;
 using Microsoft.Extensions.Options;
 
@@ -19,7 +18,7 @@ public class Worker : BackgroundService
         _options = options.Value;
         _receivers = receiverFactory.CreateAllConfigured();
     }
-    
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         foreach (var receiver in _receivers)
@@ -27,7 +26,7 @@ public class Worker : BackgroundService
             _logger.LogInformation("Starting receiver {Receiver}", receiver.GetType().Name);
             await receiver.Start(stoppingToken);
         }
-        
+
         while (!stoppingToken.IsCancellationRequested)
         {
             // _logger.LogInformation("Worker running at: {Time}", DateTimeOffset.Now);

--- a/src/BabelBot.Worker/Worker.cs
+++ b/src/BabelBot.Worker/Worker.cs
@@ -7,16 +7,28 @@ namespace BabelBot.Worker;
 public class Worker : BackgroundService
 {
     private readonly ILogger<Worker> _logger;
-
+    private readonly ICommandRegistrator _commandRegistrator;
     private readonly IEnumerable<IReceiver> _receivers;
 
     private readonly WorkerOptions _options;
 
-    public Worker(ILogger<Worker> logger, IOptions<WorkerOptions> options, ReceiverFactory receiverFactory)
+    public Worker(
+        ILogger<Worker> logger,
+        IOptions<WorkerOptions> options,
+        ICommandRegistrator commandRegistrator,
+        ReceiverFactory receiverFactory)
     {
         _logger = logger;
+        _commandRegistrator = commandRegistrator;
         _options = options.Value;
         _receivers = receiverFactory.CreateAllConfigured();
+    }
+
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await _commandRegistrator.RegisterCommands(cancellationToken);
+
+        await base.StartAsync(cancellationToken);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/BabelBot.Receiver.Commands.Tests.Unit.csproj
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/BabelBot.Receiver.Commands.Tests.Unit.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/BabelBot.Receiver.Commands.Tests.Unit.csproj
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/BabelBot.Receiver.Commands.Tests.Unit.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\BabelBot.Receiver.Commands\BabelBot.Receiver.Commands.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/CommandFactory.Tests.cs
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/CommandFactory.Tests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using BabelBot.Shared.Commands;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace BabelBot.Receiver.Commands.Tests.Unit;
+
+[TestClass]
+public class CommandFactoryTests
+{
+    private CommandFactory _factory = null!;
+    private List<ICommand> _commands = null!;
+    private ICommand _defaultCommand = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        var command = Substitute.For<ICommand>();
+        command.Keyword.Returns("cmd");
+        _defaultCommand = Substitute.For<ICommand>();
+        _defaultCommand.IsDefault.Returns(true);
+
+        _commands = new() { command, _defaultCommand };
+
+        _factory = new(_commands);
+    }
+
+    [TestMethod]
+    public void GetCommand_WithMessageWithoutCommand_ShouldReturnDefaultCommand()
+    {
+        // Arrange
+        var message = "no command here";
+
+        // Act
+        var command = _factory.GetCommand(message);
+
+        // Assert
+        Assert.AreEqual(_defaultCommand, command);
+    }
+
+    [TestMethod]
+    public void GetCommand_WithMessageWithoutCommandAndMissingDefaultCommand_ShouldThrowException()
+    {
+        // Arrange
+        var message = "no command here";
+        _commands.Remove(_defaultCommand);
+
+        // Act
+        var test = () => _factory.GetCommand(message);
+
+        // Assert
+        Assert.ThrowsException<NoDefaultCommandException>(test);
+    }
+
+    [TestMethod]
+    public void GetCommand_WithMessageWithUnknownCommand_ShouldReturnMissingCommand()
+    {
+        // Arrange
+        var message = "/unknown";
+
+        // Act
+        var command = _factory.GetCommand(message);
+
+        // Assert
+        Assert.IsInstanceOfType(command, typeof(MissingCommand));
+        Assert.AreEqual("unknown", command.Keyword);
+    }
+
+    [TestMethod]
+    public void GetCommand_WithMessageWithKnownCommand_ShouldReturnThatCommand()
+    {
+        // Arrange
+        var message = "/cmd";
+
+        // Act
+        var command = _factory.GetCommand(message);
+
+        // Assert
+        Assert.IsNotNull(command);
+    }
+}

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/AddUsersCommand.Tests.cs
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/AddUsersCommand.Tests.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Storage;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace BabelBot.Receiver.Commands.Tests.Unit;
+
+[TestClass]
+public class AddUsersCommandTests
+{
+    private AddUsersCommand _command = null!;
+    private IUsers _users = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _users = Substitute.For<IUsers>();
+
+        _command = new(_users);
+    }
+
+    [TestMethod]
+    public async Task Run_WithoutIds_ReturnsError()
+    {
+        // Act
+        var message = new ReceivedMessage { Text = "" };
+        var result = await _command.Run(new CancellationToken(), message);
+
+        // Assert
+        Assert.IsTrue(result.HasError);
+    }
+
+    [TestMethod]
+    public async Task Run_WithIds_SavesIdsAndReturnsSuccessMessage()
+    {
+        // Act
+        var message = new ReceivedMessage { Text = "1 2 3" };
+        var result = await _command.Run(new CancellationToken(), message);
+
+        // Assert
+        var expectedIds = new[] { 1L, 2L, 3L };
+        _users.Received(1).AddUsers(Arg.Is<long[]>(ids => !ids.Except(expectedIds).Any()));
+        Assert.IsTrue(result.Success);
+    }
+}

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/AddUsersCommand.Tests.cs
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/AddUsersCommand.Tests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,8 +28,8 @@ public class AddUsersCommandTests
     public async Task Run_WithoutIds_ReturnsError()
     {
         // Act
-        var message = new ReceivedMessage { Text = "" };
-        var result = await _command.Run(new CancellationToken(), message);
+        var message = new ReceivedMessage { };
+        var result = await _command.Run(message, Array.Empty<string>(), new CancellationToken());
 
         // Assert
         Assert.IsTrue(result.HasError);
@@ -37,12 +39,12 @@ public class AddUsersCommandTests
     public async Task Run_WithIds_SavesIdsAndReturnsSuccessMessage()
     {
         // Act
-        var message = new ReceivedMessage { Text = "1 2 3" };
-        var result = await _command.Run(new CancellationToken(), message);
+        var message = new ReceivedMessage { };
+        var result = await _command.Run(message, new[] { "1", "2", "3" }, new CancellationToken());
 
         // Assert
         var expectedIds = new[] { 1L, 2L, 3L };
-        _users.Received(1).AddUsers(Arg.Is<long[]>(ids => !ids.Except(expectedIds).Any()));
+        _users.Received(1).AddUsers(Arg.Is<IEnumerable<long>>(ids => !ids.Except(expectedIds).Any()));
         Assert.IsTrue(result.Success);
     }
 }

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/Command.Tests.cs
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/Command.Tests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BabelBot.Shared.Commands;
+using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Storage;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace BabelBot.Receiver.Commands.Tests.Unit;
+
+public class TestCommand : Command
+{
+    public IEnumerable<UserRole> AllowedRolesForTest;
+    public List<(ReceivedMessage, IEnumerable<string>)> Calls = new();
+
+    public TestCommand(
+        ILogger<Command> logger,
+        IUsers users)
+        : base(logger, users)
+    {
+        AllowedRolesForTest = new[] { UserRole.Superuser };
+    }
+
+    public override string Keyword => "test";
+
+    public override IEnumerable<UserRole> AllowedRoles => AllowedRolesForTest;
+
+    public override Task<Shared.Commands.CommandResult> Run(ReceivedMessage message, IEnumerable<string> commandArguments, CancellationToken cancellationToken)
+    {
+        Calls.Add((message, commandArguments));
+
+        return Task.FromResult(new CommandResult());
+    }
+}
+
+[TestClass]
+public class CommandTests
+{
+    private TestCommand _command = null!;
+    private IUsers _users = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _users = Substitute.For<IUsers>();
+        _users.GetUser(1).Returns(new User { Id = 1, Role = UserRole.Superuser });
+
+        _command = new TestCommand(Substitute.For<ILogger<Command>>(), _users);
+    }
+
+    [TestMethod]
+    public async Task Run_WithoutUserId_DoesNothing()
+    {
+        // Arrange
+        var message = new ReceivedMessage { UserId = null };
+
+        // Act
+        await _command.Run(message, new CancellationToken());
+
+        // Assert
+        Assert.IsFalse(_command.Calls.Any());
+    }
+
+    [TestMethod]
+    public async Task Run_WithInvalidUserRole_DoesNothing()
+    {
+        // Arrange
+        _users.GetUser(2).Returns(new User { Id = 2, Role = UserRole.TranslationUser });
+        var message = new ReceivedMessage { UserId = 2 };
+
+        // Act
+        await _command.Run(message, new CancellationToken());
+
+        // Assert
+        Assert.IsFalse(_command.Calls.Any());
+    }
+    public static IEnumerable<object[]> Run_WithUnknownUser_DefaultsToAnonymousUser_TestData()
+    {
+        yield return new object[] { new[] { UserRole.Superuser, UserRole.TranslationUser }, false };
+        yield return new object[] { new[] { UserRole.Anonymous }, true };
+    }
+    [TestMethod]
+    [DynamicData(nameof(Run_WithUnknownUser_DefaultsToAnonymousUser_TestData), DynamicDataSourceType.Method)]
+    public async Task Run_WithUnknownUser_DefaultsToAnonymousUser(IEnumerable<UserRole> allowedRoles, bool expected)
+    {
+        // Arrange
+        _command.AllowedRolesForTest = allowedRoles;
+        _users.GetUser(2).Returns(null as User);
+        var message = new ReceivedMessage { UserId = 2, Text = "" };
+
+        // Act
+        await _command.Run(message, new CancellationToken());
+
+        // Assert
+        Assert.AreEqual(expected, _command.Calls.Any());
+    }
+
+    [TestMethod]
+    public async Task Run_StripsCommandFromArgumentListAndProvidesMessage()
+    {
+        // Arrange
+        var message = new ReceivedMessage { UserId = 1, Text = "/test 1 2 abc" };
+
+        // Act
+        await _command.Run(message, new CancellationToken());
+
+        // Assert
+        Assert.IsTrue(_command.Calls.Any());
+
+        var call = _command.Calls.First();
+        var receivedMessage = call.Item1;
+        var receivedArguments = call.Item2;
+        Assert.AreEqual(message, receivedMessage);
+        CollectionAssert.AreEqual(new[] { "1", "2", "abc" }, receivedArguments.ToArray());
+    }
+}

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/Command.Tests.cs
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/Command.Tests.cs
@@ -25,6 +25,7 @@ public class TestCommand : Command
     }
 
     public override string Keyword => "test";
+    public override string Description => string.Empty;
 
     public override IEnumerable<UserRole> AllowedRoles => AllowedRolesForTest;
 

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/DeleteUsersCommand.Tests.cs
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/DeleteUsersCommand.Tests.cs
@@ -18,17 +18,14 @@ public class DeleteUsersCommandTests
 {
     private DeleteUsersCommand _command = null!;
     private IUsers _users = null!;
-    private TelegramOptions _options = new TelegramOptions { };
 
     [TestInitialize]
     public void Initialize()
     {
         var logger = Substitute.For<ILogger<DeleteUsersCommand>>();
         _users = Substitute.For<IUsers>();
-        var options = Substitute.For<IOptions<TelegramOptions>>();
-        options.Value.Returns(_options);
 
-        _command = new(logger, _users, options);
+        _command = new(logger, _users);
     }
 
     [TestMethod]

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/DeleteUsersCommand.Tests.cs
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/DeleteUsersCommand.Tests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Storage;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace BabelBot.Receiver.Commands.Tests.Unit;
+
+[TestClass]
+public class DeleteUsersCommandTests
+{
+    private DeleteUsersCommand _command = null!;
+    private IUsers _users = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _users = Substitute.For<IUsers>();
+
+        _command = new(_users);
+    }
+
+    [TestMethod]
+    public async Task Run_WithoutIds_ReturnsError()
+    {
+        // Act
+        var message = new ReceivedMessage { };
+        var result = await _command.Run(message, Array.Empty<string>(), new CancellationToken());
+
+        // Assert
+        Assert.IsTrue(result.HasError);
+    }
+
+    [TestMethod]
+    public async Task Run_WithIds_RemovesAndReturnsSuccessMessage()
+    {
+        // Act
+        var message = new ReceivedMessage { };
+        var result = await _command.Run(message, new[] { "1", "2", "3" }, new CancellationToken());
+
+        // Assert
+        var expectedIds = new[] { 1L, 2L, 3L };
+        _users.Received(1).DeleteUsers(Arg.Is<IEnumerable<long>>(ids => !ids.Except(expectedIds).Any()));
+        Assert.IsTrue(result.Success);
+    }
+}

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/DeleteUsersCommand.Tests.cs
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/DeleteUsersCommand.Tests.cs
@@ -4,7 +4,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Options;
 using BabelBot.Shared.Storage;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 
@@ -15,13 +18,17 @@ public class DeleteUsersCommandTests
 {
     private DeleteUsersCommand _command = null!;
     private IUsers _users = null!;
+    private TelegramOptions _options = new TelegramOptions { };
 
     [TestInitialize]
     public void Initialize()
     {
+        var logger = Substitute.For<ILogger<DeleteUsersCommand>>();
         _users = Substitute.For<IUsers>();
+        var options = Substitute.For<IOptions<TelegramOptions>>();
+        options.Value.Returns(_options);
 
-        _command = new(_users);
+        _command = new(logger, _users, options);
     }
 
     [TestMethod]
@@ -44,7 +51,31 @@ public class DeleteUsersCommandTests
 
         // Assert
         var expectedIds = new[] { 1L, 2L, 3L };
-        _users.Received(1).DeleteUsers(Arg.Is<IEnumerable<long>>(ids => !ids.Except(expectedIds).Any()));
+        _users.Received(1).DeleteTranslationUsers(Arg.Is<IEnumerable<long>>(ids => !ids.Except(expectedIds).Any()));
+        Assert.IsTrue(result.Success);
+    }
+
+    [TestMethod]
+    public async Task Run_WithSuperuserIds_RemovesAllUsersExceptTheSuperusers()
+    {
+        // Act
+        var message = new ReceivedMessage { };
+        _users.GetList(Arg.Any<Func<User, bool>>()).Returns(call =>
+        {
+            var predicate = call.Arg<Func<User, bool>>();
+
+            return new[] {
+                new User { Id = 1, Role = UserRole.Superuser },
+                new User { Id = 2, Role = UserRole.TranslationUser },
+                new User { Id = 3, Role = UserRole.Superuser },
+                new User { Id = 4, Role = UserRole.TranslationUser },
+            }.Where(predicate);
+        });
+        var result = await _command.Run(message, new[] { "1", "2", "3", "4" }, new CancellationToken());
+
+        // Assert
+        var expectedIds = new[] { 2L, 4L };
+        _users.Received(1).DeleteTranslationUsers(Arg.Is<IEnumerable<long>>(ids => !ids.Except(expectedIds).Any()));
         Assert.IsTrue(result.Success);
     }
 }

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/TranslateCommand.Tests.cs
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/TranslateCommand.Tests.cs
@@ -33,7 +33,7 @@ public class TranslateCommandTests
         _translator.TranslateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(translation));
 
         // Act
-        await _command.Run(new CancellationToken(), message);
+        await _command.Run(message, new CancellationToken());
 
         // Assert
         await _messenger.Received(1).SendTextMessage(message.ChatId, translation.Text, message.Id);
@@ -48,7 +48,7 @@ public class TranslateCommandTests
         _translator.TranslateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(translation));
 
         // Act
-        await _command.Run(new CancellationToken(), message);
+        await _command.Run(message, new CancellationToken());
 
         // Assert
         await _messenger.Received(1).SendTextMessage(message.ChatId, Arg.Is<string>(s => s.Length > 4000), message.Id);

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/TranslateCommand.Tests.cs
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/TranslateCommand.Tests.cs
@@ -1,0 +1,57 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Translation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace BabelBot.Receiver.Commands.Tests.Unit;
+
+[TestClass]
+public class TranslateCommandTests
+{
+    private TranslateCommand _command = null!;
+    private ITranslator _translator = null!;
+    private IMessenger _messenger = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _translator = Substitute.For<ITranslator>();
+
+        _messenger = Substitute.For<IMessenger>();
+
+        _command = new(_translator, _messenger);
+    }
+
+    [TestMethod]
+    public async Task Run_RepliesToMessageWithTranslation()
+    {
+        // Arrange
+        var message = new ReceivedMessage { Text = "some text", ChatId = 42, Id = 42 };
+        var translation = new TranslationResult { Text = "translation" };
+        _translator.TranslateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(translation));
+
+        // Act
+        await _command.Run(new CancellationToken(), message);
+
+        // Assert
+        await _messenger.Received(1).SendTextMessage(message.ChatId, translation.Text, message.Id);
+    }
+
+    [TestMethod]
+    public async Task Run_WithLongTranslation_SendsMultipleMessages()
+    {
+        // Arrange
+        var message = new ReceivedMessage { Text = "some text", ChatId = 42, Id = 42 };
+        var translation = new TranslationResult { Text = "translation".PadRight(5000, 'A') };
+        _translator.TranslateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(translation));
+
+        // Act
+        await _command.Run(new CancellationToken(), message);
+
+        // Assert
+        await _messenger.Received(1).SendTextMessage(message.ChatId, Arg.Is<string>(s => s.Length > 4000), message.Id);
+        await _messenger.Received(1).SendTextMessage(message.ChatId, Arg.Is<string>(s => s.Length < 4000), message.Id);
+    }
+}

--- a/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/TranslateCommand.Tests.cs
+++ b/tests/unit/BabelBot.Receiver.Commands.Tests.Unit/Commands/TranslateCommand.Tests.cs
@@ -1,7 +1,11 @@
 using System.Threading;
 using System.Threading.Tasks;
 using BabelBot.Shared.Messenger;
+using BabelBot.Shared.Options;
+using BabelBot.Shared.Storage;
 using BabelBot.Shared.Translation;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 
@@ -11,24 +15,31 @@ namespace BabelBot.Receiver.Commands.Tests.Unit;
 public class TranslateCommandTests
 {
     private TranslateCommand _command = null!;
+    private IUsers _users = null!;
     private ITranslator _translator = null!;
     private IMessenger _messenger = null!;
+    private TelegramOptions _options = new TelegramOptions { };
 
     [TestInitialize]
     public void Initialize()
     {
+        var logger = Substitute.For<ILogger<TranslateCommand>>();
+        _users = Substitute.For<IUsers>();
         _translator = Substitute.For<ITranslator>();
-
         _messenger = Substitute.For<IMessenger>();
+        var options = Substitute.For<IOptions<TelegramOptions>>();
+        options.Value.Returns(_options);
 
-        _command = new(_translator, _messenger);
+        _users.GetUser(Arg.Any<long>()).Returns(new User { Id = 1, Role = UserRole.TranslationUser });
+
+        _command = new(logger, _users, _translator, _messenger, options);
     }
 
     [TestMethod]
     public async Task Run_RepliesToMessageWithTranslation()
     {
         // Arrange
-        var message = new ReceivedMessage { Text = "some text", ChatId = 42, Id = 42 };
+        var message = new ReceivedMessage { Id = 42, Text = "some text", ChatId = 42, UserId = 1 };
         var translation = new TranslationResult { Text = "translation" };
         _translator.TranslateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(translation));
 
@@ -43,7 +54,7 @@ public class TranslateCommandTests
     public async Task Run_WithLongTranslation_SendsMultipleMessages()
     {
         // Arrange
-        var message = new ReceivedMessage { Text = "some text", ChatId = 42, Id = 42 };
+        var message = new ReceivedMessage { Id = 42, Text = "some text", ChatId = 42, UserId = 1 };
         var translation = new TranslationResult { Text = "translation".PadRight(5000, 'A') };
         _translator.TranslateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(translation));
 


### PR DESCRIPTION
This is a big one!

## Changes

- Add some more structure to `BabelBot.Shared` because it became too cluttered
- Add messenger-independent commands
  - Commands have a keyword that can be used to match it to user input
  - One command can be a default command and will be triggered if no command was provided (the translation command)
    - Technically, multiple commands could be default, but as only the first will be picked (and only translation _should_ be default), this wouldn't make much sense. This might be a sign that there's a better way to default to the translation command.
  - Current commands are: `/addusers`, `/deleteusers`, `/listusers`
  - Commands are automatically being registered with the Telegram API (doesn't seem to be any use for mobile users though)
- Add user roles and role-based restrictions
  - Currently, "initial" users are superusers and all users added using `/addusers` are "translation users"
  - Commands have role restrictions and can only be executed by users with one of the correct roles
- Add in-memory (but not true) persistence

## Outlook

(Check off what you agree with and I'll create issues or resolve it as part of this one.)

- [x] We should add true persistence
  - (Helm) We could start with an SQLite database on a volume as a default and add options to connect to an external database.
- [x] We should display user names instead of ids.
- [x] We could improve the current commands to be interactive and take the current chat members into account. See @BotFather command `/mybots` for an example of what this could look like.
- [x] We might be able to leverage built-in messenger roles: All group admins could be super users.
  - Would have the added benefit of displaying commands only to users who are allowed to see them.
